### PR TITLE
Nx graph

### DIFF
--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -2,3 +2,4 @@ toolz
 tornado
 streamz
 distributed
+networkx

--- a/streamz_ext/__init__.py
+++ b/streamz_ext/__init__.py
@@ -1,3 +1,4 @@
 __version__ = '0.2.0'
 
 from .core import *
+from .graph import create_streamz_graph

--- a/streamz_ext/graph.py
+++ b/streamz_ext/graph.py
@@ -1,1 +1,104 @@
+import networkx as nx
+
 from streamz.graph import *
+from streamz_ext import Stream
+from typing import Type
+
+
+class StreamzGraph(nx.DiGraph):
+
+    def _node_name(self, node):
+        n = getattr(node, 'name', hash(node))
+        if n is None:
+            n = hash(node)
+        return n
+
+    def add_node(self, node: Type[Stream] or Stream, *args, **kwargs):
+        # None is used as a place holder for the upstream/upstreams if any
+        if isinstance(node, type) or callable(node):
+            node = node(None, *args, **kwargs)
+        n = self._node_name(node)
+        super().add_node(n, node=node)
+        return n
+
+    def add_edge(self, u: str or tuple, v: str or tuple, **attrs):
+        new_uv = []
+        for uv in [u, v]:
+            if isinstance(uv, tuple):
+                a, b, c = uv
+                if not b:
+                    b = ()
+                if not c:
+                    c = {}
+                new_uv.append(self.add_node(a, *b, **c))
+            else:
+                new_uv.append(uv)
+        u, v = new_uv
+        if (u, v) in self.edges or (v, u) in self.edges:
+            return
+        # Need to remove old references when overriding
+
+        un = self.nodes[u]['node']
+        vn = self.nodes[v]['node']
+        if un not in vn.upstreams:
+            if self._node_name(un) in [self._node_name(n) for n in vn.upstreams]:
+                # get the index of the node to be replaced
+                l = [self._node_name(n) for n in vn.upstreams]
+                idx = l.index(self._node_name(un))
+                # perform the connection
+                un.connect(vn)
+                # pop the old to make way for the new
+                new = vn.upstreams.pop(-1)
+                vn.upstreams.insert(idx, new)
+                vn.upstreams[idx + 1].disconnect(vn)
+            else:
+                un.connect(vn)
+        super().add_edge(u, v)
+
+    def add_edges_from(self, ebunch, **attrs):
+        for u, v, *d in ebunch:
+            self.add_edge(u, v)
+
+    def add_nodes_from(self, nodes, **attr):
+        for n in nodes:
+            if len(n) == 2:
+                n = n[1]['node']
+            self.add_node(n)
+
+    def fresh_copy(self):
+        return StreamzGraph()
+
+
+def _create_streamz_graph(node, graph, prior_node=None, pc=None):
+    """Create graph from a single node, searching up and down the chain
+
+    Parameters
+    ----------
+    node: Stream instance
+    graph: StreamzGraph instance
+    """
+    if node is None:
+        return
+    t = graph.add_node(node)
+    if prior_node:
+        tt = getattr(prior_node, 'name', hash(prior_node))
+        if tt is None:
+            tt = hash(prior_node)
+        if graph.has_edge(t, tt) or graph.has_edge(tt, t):
+            return
+        if pc == 'downstream':
+            graph.add_edge(tt, t)
+        else:
+            graph.add_edge(t, tt)
+
+    for nodes, pc in zip([list(node.downstreams), list(node.upstreams)],
+                         ['downstream', 'upstreams']):
+        for node2 in nodes:
+            if node2 is not None:
+                _create_streamz_graph(node2, graph, node, pc=pc)
+
+
+def create_streamz_graph(node):
+    g = StreamzGraph()
+    _create_streamz_graph(node, g)
+    return g

--- a/streamz_ext/link.py
+++ b/streamz_ext/link.py
@@ -1,41 +1,22 @@
+import networkx as nx
+
+from .graph import StreamzGraph
 
 
-# TODO: should the inputs and outputs be defined as kwargs for the pipeline
-# generating function?
-# This would make the requirements more explicit and have a linker error
-# maybe we use sig f(*, kwarg1, kwarg2, **kwargs)?
-def micro_link(input_graph, output_graph):
-    """Link to dicts of sub graphs together by their keys
-
-    Parameters
-    ----------
-    input_graph : dict of Streams
-    output_graph : dict of Streams
-    """
-    for name in output_graph:
-        if name in input_graph:
-            input_graph[name].connect(output_graph[name])
-    # TODO: idiomatic way to do this? (essentially left update)
-    input_graph.update(
-        {k: v for k, v in output_graph.items() if k not in input_graph})
-
-
-# TODO: support bypass? Maybe that should be a separate pipeline optimization
-# step
 def link(*args):
     """Link a series of sub graphs in order
 
     Parameters
     ----------
-    args : iterable of dicts of Streams
+    args : iterable of StreamzGraph
 
     Returns
     -------
-    dict of Streams:
-        The the final pipeline dict
+    StreamzGraph:
+        The the final pipeline StreamzGraph
 
     """
-    total_graph = {}
+    total_graph = StreamzGraph()
     for graph in args:
-        micro_link(total_graph, graph)
+        total_graph = nx.compose(graph, total_graph)
     return total_graph

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -1,5 +1,65 @@
 from streamz_ext.graph import *
+
 try:
     from streamz.tests.test_graph import *
 except ImportError:
     pass
+
+
+def test_streamz_graph():
+    a = StreamzGraph()
+    a.add_node(Stream, stream_name='a')
+    z = Stream(stream_name='b')
+    a.add_node(z)
+    a.add_edge('a', (Stream.union, None, dict(stream_name='c')))
+    a.add_edge('b', 'c')
+    assert len(a) == 3
+    l = a.nodes['c']['node'].sink_to_list()
+
+    for i in range(5):
+        a.nodes['a']['node'].emit(i)
+
+    assert len(l) == 5
+
+
+def test_compose_graph():
+    def makea():
+        a = StreamzGraph()
+        a.add_node(Stream, stream_name='a')
+        z = Stream(stream_name='b')
+        a.add_node(z)
+        a.add_edge('a', (Stream.union, None, dict(stream_name='c')))
+        a.add_edge('b', 'c')
+        return a
+
+    l = []
+
+    def makeb():
+        a = StreamzGraph()
+        a.add_node(Stream, stream_name='c')
+        a.add_edge('c', (Stream.sink, (lambda x: l.append(x),), {}))
+        return a
+
+    z = makea()
+    zz = makeb()
+    zzz = nx.compose(zz, z)
+    for i in range(5):
+        zzz.nodes['a']['node'].emit(i)
+        zzz.nodes['b']['node'].emit(i)
+    assert len(l) == 10
+
+
+def test_create_streamz_graph():
+    a = Stream(stream_name='source')
+    b = a.map(lambda x: x + 1)
+    L = b.sink_to_list()
+
+    z = create_streamz_graph(a)
+    assert len(z) == 3
+    ll = []
+    for i in range(5):
+        a.emit(i)
+        ll.append(i + 1)
+        z.nodes['source']['node'].emit(i)
+        ll.append(i + 1)
+    assert L == ll

--- a/test/test_link.py
+++ b/test/test_link.py
@@ -1,5 +1,5 @@
 from streamz_ext.link import *
-from streamz_ext import Stream
+from streamz_ext import Stream, create_streamz_graph
 try:
     from streamz.tests.test_link import *
 except ImportError:
@@ -8,105 +8,54 @@ except ImportError:
 
 def test_link():
     def make_a():
-        source = Stream()
-        out_a = source.map(lambda x: x + 1)
-        return {'in_a': source, 'out_a': out_a}
+        out_a = Stream(stream_name='in_a').map(lambda x: x + 1,
+                                               stream_name='out_a')
+        return create_streamz_graph(out_a)
 
     def make_b():
-        out_a = Stream()
-        out_b = out_a.map(lambda x: x * 2)
-        return {'out_a': out_a, 'out_b': out_b}
+        out_b = Stream(stream_name='out_a').map(lambda x: x * 2,
+                                                stream_name='out_b')
+        return create_streamz_graph(out_b)
     a = make_a()
     b = make_b()
-    L = b['out_b'].sink_to_list()
+    L = b.node['out_b']['node'].sink_to_list()
     for i in range(10):
-        a['in_a'].emit(i)
+        a.node['in_a']['node'].emit(i)
     assert len(L) == 0
-    link(a, b)
+    z = link(a, b)
     for i in range(10):
-        a['in_a'].emit(i)
+        a.node['in_a']['node'].emit(i)
     assert L == [(i + 1) * 2 for i in range(10)]
-
-
-# def test_link_bypass():
-#     def make_a():
-#         source = Stream()
-#         out_a = source.map(lambda x: x + 1)
-#         return {'in_a': source, 'out_a': out_a}
-#
-#     def make_b():
-#         out_a = Stream()
-#         out_b = out_a.map(lambda x: x * 2)
-#         return {'out_a': out_a, 'out_b': out_b}
-#     a = make_a()
-#     b = make_b()
-#     L = b['out_b'].sink_to_list()
-#     for i in range(10):
-#         a['in_a'].emit(i)
-#     assert len(L) == 0
-#     link(a, b, bypass=True)
-#     for i in range(10):
-#         a['in_a'].emit(i)
-#     assert L == [(i + 1) * 2 for i in range(10)]
 
 
 def test_double_link():
     def make_a():
-        source = Stream()
-        out_a = source.map(lambda x: x + 1)
-        return {'in_a': source, 'out_a': out_a}
+        out_a = Stream(stream_name='in_a').map(lambda x: x + 1,
+                                               stream_name='out_a')
+        return create_streamz_graph(out_a)
 
     def make_b():
-        out_a = Stream()
-        out_b = out_a.map(lambda x: x * 2)
-        return {'out_a': out_a, 'out_b': out_b}
+        out_b = Stream(stream_name='out_a').map(lambda x: x * 2,
+                                                stream_name='out_b')
+        return create_streamz_graph(out_b)
 
     def make_c():
-        out_a = Stream()
-        out_b = Stream()
-        out_c = out_a.zip(out_b).map(sum)
-        return {'out_a': out_a, 'out_b': out_b, 'out_c': out_c}
+        a = Stream(stream_name='out_a')
+        b = Stream(stream_name='out_b')
+        a_zip = a.zip(b, stream_name='z')
+        out_c = a_zip.map(sum, stream_name='out_c')
+        return create_streamz_graph(out_c)
 
     a = make_a()
     b = make_b()
-    L = b['out_b'].sink_to_list()
+    L = b.node['out_b']['node'].sink_to_list()
     ab = link(a, b)
     c = make_c()
-    L2 = c['out_c'].sink_to_list()
+    L2 = c.node['out_c']['node'].sink_to_list()
     abc = link(ab, c)
+    assert len(c.node['z']['node'].upstreams) == 2
 
     for i in range(10):
-        a['in_a'].emit(i)
+        abc.node['in_a']['node'].emit(i)
     assert L == [(i + 1) * 2 for i in range(10)]
     assert L2 == [((i + 1) * 2) + i + 1 for i in range(10)]
-
-
-# def test_double_link_bypass():
-#     def make_a():
-#         source = Stream()
-#         out_a = source.map(lambda x: x + 1)
-#         return {'in_a': source, 'out_a': out_a}
-#
-#     def make_b():
-#         out_a = Stream()
-#         out_b = out_a.map(lambda x: x * 2)
-#         return {'out_a': out_a, 'out_b': out_b}
-#
-#     def make_c():
-#         out_a = Stream()
-#         out_b = Stream()
-#         out_c = out_a.zip(out_b).map(sum)
-#         return {'out_a': out_a, 'out_b': out_b, 'out_c': out_c}
-#
-#     a = make_a()
-#     b = make_b()
-#     L = b['out_b'].sink_to_list()
-#     ab = link(a, b, bypass=True)
-#     c = make_c()
-#     L2 = c['out_c'].sink_to_list()
-#     abc = link(ab, c, bypass=True)
-#
-#     for i in range(10):
-#         a['in_a'].emit(i)
-#     assert L == [(i + 1) * 2 for i in range(10)]
-#     assert L2 == [((i + 1) * 2) + i + 1 for i in range(10)]


### PR DESCRIPTION
This is one of the more difficult PRs that I've worked on. This allows Streamz graphs to be formed into a `StreamzGraph` object which is a subclass of `nx.DiGraph`. The benefit of this is that we can now make the `StreamzGraph` for each chunk of the pipeline and link them together without having to rely on dictionaries that happen to have the correct keys. This also helps to remove excess nodes from the graph.